### PR TITLE
Add environment variable overrides for CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # snek
 
-![Build Status](https://github.com/ronelliott/snek/actions/workflows/master.yml/badge.svg)
+![Build Status](https://github.com/ronelliott/snek/actions/workflows/main.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ronelliott/snek)](https://goreportcard.com/report/github.com/ronelliott/snek)
 [![Coverage Status](https://coveralls.io/repos/github/ronelliott/snek/badge.svg?branch=master)](https://coveralls.io/github/ronelliott/snek?branch=master)
 [![Go Reference](https://pkg.go.dev/badge/github.com/ronelliott/snek.svg)](https://pkg.go.dev/github.com/ronelliott/snek)
@@ -117,6 +117,49 @@ Flags can be added to a generated command by calling the `WithFlags` function wi
 | WithStringVar | Add a `string` flag with only a long name. |
 | WithStringVarP | Add a `string` flag with a long and short name. |
 
+### Environment Variable Overrides
+
+Each flag type also has an `E` variant (`WithBoolVarE`, `WithStringVarPE`, etc.) that accepts an environment variable name. When the environment variable is set, its value is used as the flag's default. The priority order is:
+
+1. Explicit CLI flag (highest)
+2. Environment variable
+3. Hardcoded default value (lowest)
+
+If the environment variable is set but cannot be parsed into the flag's type, `NewCommand` returns an error wrapping `ErrFlagEnvVarInvalid`.
+
+| Name | Description |
+| - | - |
+| WithBoolVarE | Add a `bool` flag with only a long name and an environment variable override. |
+| WithBoolVarPE | Add a `bool` flag with a long and short name and an environment variable override. |
+| WithDurationVarE | Add a `time.Duration` flag with only a long name and an environment variable override. |
+| WithDurationVarPE | Add a `time.Duration` flag with a long and short name and an environment variable override. |
+| WithFloat32VarE | Add a `float32` flag with only a long name and an environment variable override. |
+| WithFloat32VarPE | Add a `float32` flag with a long and short name and an environment variable override. |
+| WithFloat64VarE | Add a `float64` flag with only a long name and an environment variable override. |
+| WithFloat64VarPE | Add a `float64` flag with a long and short name and an environment variable override. |
+| WithIntVarE | Add an `int` flag with only a long name and an environment variable override. |
+| WithIntVarPE | Add an `int` flag with a long and short name and an environment variable override. |
+| WithInt8VarE | Add an `int8` flag with only a long name and an environment variable override. |
+| WithInt8VarPE | Add an `int8` flag with a long and short name and an environment variable override. |
+| WithInt16VarE | Add an `int16` flag with only a long name and an environment variable override. |
+| WithInt16VarPE | Add an `int16` flag with a long and short name and an environment variable override. |
+| WithInt32VarE | Add an `int32` flag with only a long name and an environment variable override. |
+| WithInt32VarPE | Add an `int32` flag with a long and short name and an environment variable override. |
+| WithInt64VarE | Add an `int64` flag with only a long name and an environment variable override. |
+| WithInt64VarPE | Add an `int64` flag with a long and short name and an environment variable override. |
+| WithUintVarE | Add a `uint` flag with only a long name and an environment variable override. |
+| WithUintVarPE | Add a `uint` flag with a long and short name and an environment variable override. |
+| WithUint8VarE | Add a `uint8` flag with only a long name and an environment variable override. |
+| WithUint8VarPE | Add a `uint8` flag with a long and short name and an environment variable override. |
+| WithUint16VarE | Add a `uint16` flag with only a long name and an environment variable override. |
+| WithUint16VarPE | Add a `uint16` flag with a long and short name and an environment variable override. |
+| WithUint32VarE | Add a `uint32` flag with only a long name and an environment variable override. |
+| WithUint32VarPE | Add a `uint32` flag with a long and short name and an environment variable override. |
+| WithUint64VarE | Add a `uint64` flag with only a long name and an environment variable override. |
+| WithUint64VarPE | Add a `uint64` flag with a long and short name and an environment variable override. |
+| WithStringVarE | Add a `string` flag with only a long name and an environment variable override. |
+| WithStringVarPE | Add a `string` flag with a long and short name and an environment variable override. |
+
 ### Example
 
 ```go
@@ -126,6 +169,19 @@ cmd, err := snek.NewCommand(
 	snek.WithFlag(
 		snek.WithStringVarP(&greeting, "greeting", "g", greeting, "The greeting to use"),
 		snek.WithStringVarP(&quantity, "quantity", "q", quantity, "The quantity of times to greet"),
+	),
+	// ...
+)
+```
+
+### Example with Environment Variable Override
+
+```go
+port := ":3000"
+cmd, err := snek.NewCommand(
+	snek.WithFlag(
+		// MY_APP_PORT env var sets the default; --port flag overrides it
+		snek.WithStringVarPE(&port, "port", "p", "MY_APP_PORT", port, "The port to bind to"),
 	),
 	// ...
 )

--- a/errors.go
+++ b/errors.go
@@ -27,4 +27,8 @@ var (
 
 	// ErrLogOutputEmpty is returned when the log output is empty or nil.
 	ErrLogOutputEmpty = errors.New("log output is empty")
+
+	// ErrFlagEnvVarInvalid is returned when an environment variable value cannot
+	// be parsed into the type required by a flag.
+	ErrFlagEnvVarInvalid = errors.New("environment variable value is invalid for flag type")
 )

--- a/flags_env.go
+++ b/flags_env.go
@@ -1,0 +1,583 @@
+package snek
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+// WithBoolVarE adds a bool flag to the command with the specified name, value,
+// and usage. If the environment variable envVar is set, its value is used as
+// the default instead of value. The variable stores the final flag value.
+func WithBoolVarE(variable *bool, name, envVar string, value bool, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.BoolVar(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithBoolVarPE adds a bool flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithBoolVarPE(variable *bool, name, shorthand, envVar string, value bool, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.BoolVarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithDurationVarE adds a duration flag to the command with the specified name,
+// value, and usage. If the environment variable envVar is set, its value is
+// used as the default instead of value. The variable stores the final flag value.
+func WithDurationVarE(variable *time.Duration, name, envVar string, value time.Duration, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := time.ParseDuration(v)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.DurationVar(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithDurationVarPE adds a duration flag to the command with the specified
+// name, shorthand, value, and usage. If the environment variable envVar is
+// set, its value is used as the default instead of value. The variable stores
+// the final flag value.
+func WithDurationVarPE(variable *time.Duration, name, shorthand, envVar string, value time.Duration, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := time.ParseDuration(v)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.DurationVarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithFloat32VarE adds a float32 flag to the command with the specified name,
+// value, and usage. If the environment variable envVar is set, its value is
+// used as the default instead of value. The variable stores the final flag value.
+func WithFloat32VarE(variable *float32, name, envVar string, value float32, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseFloat(v, 32)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = float32(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Float32Var(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithFloat32VarPE adds a float32 flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithFloat32VarPE(variable *float32, name, shorthand, envVar string, value float32, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseFloat(v, 32)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = float32(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Float32VarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithFloat64VarE adds a float64 flag to the command with the specified name,
+// value, and usage. If the environment variable envVar is set, its value is
+// used as the default instead of value. The variable stores the final flag value.
+func WithFloat64VarE(variable *float64, name, envVar string, value float64, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Float64Var(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithFloat64VarPE adds a float64 flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithFloat64VarPE(variable *float64, name, shorthand, envVar string, value float64, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Float64VarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithIntVarE adds an int flag to the command with the specified name, value,
+// and usage. If the environment variable envVar is set, its value is used as
+// the default instead of value. The variable stores the final flag value.
+func WithIntVarE(variable *int, name, envVar string, value int, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.IntVar(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithIntVarPE adds an int flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithIntVarPE(variable *int, name, shorthand, envVar string, value int, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.IntVarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithInt8VarE adds an int8 flag to the command with the specified name, value,
+// and usage. If the environment variable envVar is set, its value is used as
+// the default instead of value. The variable stores the final flag value.
+func WithInt8VarE(variable *int8, name, envVar string, value int8, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseInt(v, 10, 8)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = int8(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Int8Var(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithInt8VarPE adds an int8 flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithInt8VarPE(variable *int8, name, shorthand, envVar string, value int8, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseInt(v, 10, 8)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = int8(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Int8VarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithInt16VarE adds an int16 flag to the command with the specified name,
+// value, and usage. If the environment variable envVar is set, its value is
+// used as the default instead of value. The variable stores the final flag value.
+func WithInt16VarE(variable *int16, name, envVar string, value int16, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseInt(v, 10, 16)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = int16(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Int16Var(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithInt16VarPE adds an int16 flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithInt16VarPE(variable *int16, name, shorthand, envVar string, value int16, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseInt(v, 10, 16)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = int16(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Int16VarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithInt32VarE adds an int32 flag to the command with the specified name,
+// value, and usage. If the environment variable envVar is set, its value is
+// used as the default instead of value. The variable stores the final flag value.
+func WithInt32VarE(variable *int32, name, envVar string, value int32, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseInt(v, 10, 32)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = int32(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Int32Var(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithInt32VarPE adds an int32 flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithInt32VarPE(variable *int32, name, shorthand, envVar string, value int32, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseInt(v, 10, 32)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = int32(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Int32VarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithInt64VarE adds an int64 flag to the command with the specified name,
+// value, and usage. If the environment variable envVar is set, its value is
+// used as the default instead of value. The variable stores the final flag value.
+func WithInt64VarE(variable *int64, name, envVar string, value int64, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Int64Var(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithInt64VarPE adds an int64 flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithInt64VarPE(variable *int64, name, shorthand, envVar string, value int64, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Int64VarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithUintVarE adds a uint flag to the command with the specified name, value,
+// and usage. If the environment variable envVar is set, its value is used as
+// the default instead of value. The variable stores the final flag value.
+func WithUintVarE(variable *uint, name, envVar string, value uint, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseUint(v, 10, strconv.IntSize)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = uint(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.UintVar(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithUintVarPE adds a uint flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithUintVarPE(variable *uint, name, shorthand, envVar string, value uint, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseUint(v, 10, strconv.IntSize)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = uint(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.UintVarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithUint8VarE adds a uint8 flag to the command with the specified name,
+// value, and usage. If the environment variable envVar is set, its value is
+// used as the default instead of value. The variable stores the final flag value.
+func WithUint8VarE(variable *uint8, name, envVar string, value uint8, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseUint(v, 10, 8)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = uint8(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Uint8Var(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithUint8VarPE adds a uint8 flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithUint8VarPE(variable *uint8, name, shorthand, envVar string, value uint8, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseUint(v, 10, 8)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = uint8(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Uint8VarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithUint16VarE adds a uint16 flag to the command with the specified name,
+// value, and usage. If the environment variable envVar is set, its value is
+// used as the default instead of value. The variable stores the final flag value.
+func WithUint16VarE(variable *uint16, name, envVar string, value uint16, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseUint(v, 10, 16)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = uint16(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Uint16Var(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithUint16VarPE adds a uint16 flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithUint16VarPE(variable *uint16, name, shorthand, envVar string, value uint16, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseUint(v, 10, 16)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = uint16(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Uint16VarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithUint32VarE adds a uint32 flag to the command with the specified name,
+// value, and usage. If the environment variable envVar is set, its value is
+// used as the default instead of value. The variable stores the final flag value.
+func WithUint32VarE(variable *uint32, name, envVar string, value uint32, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = uint32(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Uint32Var(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithUint32VarPE adds a uint32 flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithUint32VarPE(variable *uint32, name, shorthand, envVar string, value uint32, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = uint32(parsed)
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Uint32VarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithUint64VarE adds a uint64 flag to the command with the specified name,
+// value, and usage. If the environment variable envVar is set, its value is
+// used as the default instead of value. The variable stores the final flag value.
+func WithUint64VarE(variable *uint64, name, envVar string, value uint64, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Uint64Var(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithUint64VarPE adds a uint64 flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithUint64VarPE(variable *uint64, name, shorthand, envVar string, value uint64, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		parsed, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			return func(*pflag.FlagSet) error {
+				return fmt.Errorf("%w: %s=%q: %v", ErrFlagEnvVarInvalid, envVar, v, err)
+			}
+		}
+		value = parsed
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.Uint64VarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}
+
+// WithStringVarE adds a string flag to the command with the specified name,
+// value, and usage. If the environment variable envVar is set, its value is
+// used as the default instead of value. The variable stores the final flag value.
+func WithStringVarE(variable *string, name, envVar, value, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		value = v
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.StringVar(variable, name, value, usage)
+		return nil
+	}
+}
+
+// WithStringVarPE adds a string flag to the command with the specified name,
+// shorthand, value, and usage. If the environment variable envVar is set, its
+// value is used as the default instead of value. The variable stores the final
+// flag value.
+func WithStringVarPE(variable *string, name, shorthand, envVar, value, usage string) FlagInitializer {
+	if v, ok := os.LookupEnv(envVar); ok {
+		value = v
+	}
+	return func(flags *pflag.FlagSet) error {
+		flags.StringVarP(variable, name, shorthand, value, usage)
+		return nil
+	}
+}

--- a/flags_env_test.go
+++ b/flags_env_test.go
@@ -1,0 +1,1186 @@
+package snek_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ronelliott/snek"
+)
+
+type flagEnvTest[T any] struct {
+	args        []string
+	envValue    string
+	setEnv      bool
+	expected    T
+	wantInitErr bool
+}
+
+func runFlagEnvTest[T any](
+	t *testing.T,
+	envVar string,
+	defaultValue T,
+	initializer func(*T, string, T) snek.FlagInitializer,
+	tests map[string]flagEnvTest[T],
+) {
+	t.Helper()
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if test.setEnv {
+				t.Setenv(envVar, test.envValue)
+			}
+
+			var testValue T
+			cmd, err := snek.NewCommand(snek.WithFlag(initializer(&testValue, envVar, defaultValue)))
+			if test.wantInitErr {
+				require.ErrorIs(t, err, snek.ErrFlagEnvVarInvalid)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, cmd)
+
+			cmd.SetArgs(test.args)
+			require.NoError(t, cmd.Execute())
+			assert.Equal(t, test.expected, testValue)
+		})
+	}
+}
+
+// ---- bool ----
+
+func TestWithBoolVarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_BOOL",
+		false,
+		func(variable *bool, envVar string, value bool) snek.FlagInitializer {
+			return snek.WithBoolVarE(variable, "test", envVar, value, "test bool")
+		},
+		map[string]flagEnvTest[bool]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: false,
+			},
+			"env var true, no flag": {
+				args:     []string{},
+				envValue: "true",
+				setEnv:   true,
+				expected: true,
+			},
+			"env var false, no flag": {
+				args:     []string{},
+				envValue: "false",
+				setEnv:   false,
+				expected: false,
+			},
+			"cli flag overrides env var false": {
+				args:     []string{"--test"},
+				envValue: "false",
+				setEnv:   true,
+				expected: true,
+			},
+			"invalid env var": {
+				envValue:    "notabool",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithBoolVarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_BOOL",
+		false,
+		func(variable *bool, envVar string, value bool) snek.FlagInitializer {
+			return snek.WithBoolVarPE(variable, "test", "t", envVar, value, "test bool")
+		},
+		map[string]flagEnvTest[bool]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: false,
+			},
+			"env var true, no flag": {
+				args:     []string{},
+				envValue: "true",
+				setEnv:   true,
+				expected: true,
+			},
+			"long flag overrides env var false": {
+				args:     []string{"--test"},
+				envValue: "false",
+				setEnv:   true,
+				expected: true,
+			},
+			"short flag overrides env var false": {
+				args:     []string{"-t"},
+				envValue: "false",
+				setEnv:   true,
+				expected: true,
+			},
+			"invalid env var": {
+				envValue:    "notabool",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- duration ----
+
+func TestWithDurationVarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_DURATION",
+		time.Duration(0),
+		func(variable *time.Duration, envVar string, value time.Duration) snek.FlagInitializer {
+			return snek.WithDurationVarE(variable, "test", envVar, value, "test duration")
+		},
+		map[string]flagEnvTest[time.Duration]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "5s",
+				setEnv:   true,
+				expected: 5 * time.Second,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=30s"},
+				envValue: "5s",
+				setEnv:   true,
+				expected: 30 * time.Second,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "1m"},
+				expected: time.Minute,
+			},
+			"invalid env var": {
+				envValue:    "notaduration",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithDurationVarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_DURATION",
+		time.Duration(0),
+		func(variable *time.Duration, envVar string, value time.Duration) snek.FlagInitializer {
+			return snek.WithDurationVarPE(variable, "test", "t", envVar, value, "test duration")
+		},
+		map[string]flagEnvTest[time.Duration]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "5s",
+				setEnv:   true,
+				expected: 5 * time.Second,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=30s"},
+				envValue: "5s",
+				setEnv:   true,
+				expected: 30 * time.Second,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "10s"},
+				envValue: "5s",
+				setEnv:   true,
+				expected: 10 * time.Second,
+			},
+			"invalid env var": {
+				envValue:    "notaduration",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- float32 ----
+
+func TestWithFloat32VarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_FLOAT32",
+		float32(0),
+		func(variable *float32, envVar string, value float32) snek.FlagInitializer {
+			return snek.WithFloat32VarE(variable, "test", envVar, value, "test float32")
+		},
+		map[string]flagEnvTest[float32]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "1.5",
+				setEnv:   true,
+				expected: 1.5,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=3.14"},
+				envValue: "1.5",
+				setEnv:   true,
+				expected: 3.14,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "2.5"},
+				expected: 2.5,
+			},
+			"invalid env var": {
+				envValue:    "notafloat",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithFloat32VarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_FLOAT32",
+		float32(0),
+		func(variable *float32, envVar string, value float32) snek.FlagInitializer {
+			return snek.WithFloat32VarPE(variable, "test", "t", envVar, value, "test float32")
+		},
+		map[string]flagEnvTest[float32]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "1.5",
+				setEnv:   true,
+				expected: 1.5,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=3.14"},
+				envValue: "1.5",
+				setEnv:   true,
+				expected: 3.14,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "2.5"},
+				envValue: "1.5",
+				setEnv:   true,
+				expected: 2.5,
+			},
+			"invalid env var": {
+				envValue:    "notafloat",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- float64 ----
+
+func TestWithFloat64VarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_FLOAT64",
+		float64(0),
+		func(variable *float64, envVar string, value float64) snek.FlagInitializer {
+			return snek.WithFloat64VarE(variable, "test", envVar, value, "test float64")
+		},
+		map[string]flagEnvTest[float64]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "1.5",
+				setEnv:   true,
+				expected: 1.5,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=3.14"},
+				envValue: "1.5",
+				setEnv:   true,
+				expected: 3.14,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "2.5"},
+				expected: 2.5,
+			},
+			"invalid env var": {
+				envValue:    "notafloat",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithFloat64VarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_FLOAT64",
+		float64(0),
+		func(variable *float64, envVar string, value float64) snek.FlagInitializer {
+			return snek.WithFloat64VarPE(variable, "test", "t", envVar, value, "test float64")
+		},
+		map[string]flagEnvTest[float64]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "1.5",
+				setEnv:   true,
+				expected: 1.5,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=3.14"},
+				envValue: "1.5",
+				setEnv:   true,
+				expected: 3.14,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "2.5"},
+				envValue: "1.5",
+				setEnv:   true,
+				expected: 2.5,
+			},
+			"invalid env var": {
+				envValue:    "notafloat",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- int ----
+
+func TestWithIntVarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_INT",
+		0,
+		func(variable *int, envVar string, value int) snek.FlagInitializer {
+			return snek.WithIntVarE(variable, "test", envVar, value, "test int")
+		},
+		map[string]flagEnvTest[int]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "7"},
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notanint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithIntVarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_INT",
+		0,
+		func(variable *int, envVar string, value int) snek.FlagInitializer {
+			return snek.WithIntVarPE(variable, "test", "t", envVar, value, "test int")
+		},
+		map[string]flagEnvTest[int]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "7"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notanint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- int8 ----
+
+func TestWithInt8VarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_INT8",
+		int8(0),
+		func(variable *int8, envVar string, value int8) snek.FlagInitializer {
+			return snek.WithInt8VarE(variable, "test", envVar, value, "test int8")
+		},
+		map[string]flagEnvTest[int8]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "7"},
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notanint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithInt8VarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_INT8",
+		int8(0),
+		func(variable *int8, envVar string, value int8) snek.FlagInitializer {
+			return snek.WithInt8VarPE(variable, "test", "t", envVar, value, "test int8")
+		},
+		map[string]flagEnvTest[int8]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "7"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notanint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- int16 ----
+
+func TestWithInt16VarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_INT16",
+		int16(0),
+		func(variable *int16, envVar string, value int16) snek.FlagInitializer {
+			return snek.WithInt16VarE(variable, "test", envVar, value, "test int16")
+		},
+		map[string]flagEnvTest[int16]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "7"},
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notanint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithInt16VarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_INT16",
+		int16(0),
+		func(variable *int16, envVar string, value int16) snek.FlagInitializer {
+			return snek.WithInt16VarPE(variable, "test", "t", envVar, value, "test int16")
+		},
+		map[string]flagEnvTest[int16]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "7"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notanint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- int32 ----
+
+func TestWithInt32VarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_INT32",
+		int32(0),
+		func(variable *int32, envVar string, value int32) snek.FlagInitializer {
+			return snek.WithInt32VarE(variable, "test", envVar, value, "test int32")
+		},
+		map[string]flagEnvTest[int32]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "7"},
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notanint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithInt32VarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_INT32",
+		int32(0),
+		func(variable *int32, envVar string, value int32) snek.FlagInitializer {
+			return snek.WithInt32VarPE(variable, "test", "t", envVar, value, "test int32")
+		},
+		map[string]flagEnvTest[int32]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "7"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notanint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- int64 ----
+
+func TestWithInt64VarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_INT64",
+		int64(0),
+		func(variable *int64, envVar string, value int64) snek.FlagInitializer {
+			return snek.WithInt64VarE(variable, "test", envVar, value, "test int64")
+		},
+		map[string]flagEnvTest[int64]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "7"},
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notanint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithInt64VarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_INT64",
+		int64(0),
+		func(variable *int64, envVar string, value int64) snek.FlagInitializer {
+			return snek.WithInt64VarPE(variable, "test", "t", envVar, value, "test int64")
+		},
+		map[string]flagEnvTest[int64]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "7"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notanint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- uint ----
+
+func TestWithUintVarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_UINT",
+		uint(0),
+		func(variable *uint, envVar string, value uint) snek.FlagInitializer {
+			return snek.WithUintVarE(variable, "test", envVar, value, "test uint")
+		},
+		map[string]flagEnvTest[uint]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "7"},
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notauint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithUintVarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_UINT",
+		uint(0),
+		func(variable *uint, envVar string, value uint) snek.FlagInitializer {
+			return snek.WithUintVarPE(variable, "test", "t", envVar, value, "test uint")
+		},
+		map[string]flagEnvTest[uint]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "7"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notauint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- uint8 ----
+
+func TestWithUint8VarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_UINT8",
+		uint8(0),
+		func(variable *uint8, envVar string, value uint8) snek.FlagInitializer {
+			return snek.WithUint8VarE(variable, "test", envVar, value, "test uint8")
+		},
+		map[string]flagEnvTest[uint8]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "7"},
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notauint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithUint8VarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_UINT8",
+		uint8(0),
+		func(variable *uint8, envVar string, value uint8) snek.FlagInitializer {
+			return snek.WithUint8VarPE(variable, "test", "t", envVar, value, "test uint8")
+		},
+		map[string]flagEnvTest[uint8]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "7"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notauint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- uint16 ----
+
+func TestWithUint16VarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_UINT16",
+		uint16(0),
+		func(variable *uint16, envVar string, value uint16) snek.FlagInitializer {
+			return snek.WithUint16VarE(variable, "test", envVar, value, "test uint16")
+		},
+		map[string]flagEnvTest[uint16]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "7"},
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notauint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithUint16VarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_UINT16",
+		uint16(0),
+		func(variable *uint16, envVar string, value uint16) snek.FlagInitializer {
+			return snek.WithUint16VarPE(variable, "test", "t", envVar, value, "test uint16")
+		},
+		map[string]flagEnvTest[uint16]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "7"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notauint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- uint32 ----
+
+func TestWithUint32VarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_UINT32",
+		uint32(0),
+		func(variable *uint32, envVar string, value uint32) snek.FlagInitializer {
+			return snek.WithUint32VarE(variable, "test", envVar, value, "test uint32")
+		},
+		map[string]flagEnvTest[uint32]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "7"},
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notauint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithUint32VarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_UINT32",
+		uint32(0),
+		func(variable *uint32, envVar string, value uint32) snek.FlagInitializer {
+			return snek.WithUint32VarPE(variable, "test", "t", envVar, value, "test uint32")
+		},
+		map[string]flagEnvTest[uint32]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "7"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notauint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- uint64 ----
+
+func TestWithUint64VarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_UINT64",
+		uint64(0),
+		func(variable *uint64, envVar string, value uint64) snek.FlagInitializer {
+			return snek.WithUint64VarE(variable, "test", envVar, value, "test uint64")
+		},
+		map[string]flagEnvTest[uint64]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "7"},
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notauint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+func TestWithUint64VarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_UINT64",
+		uint64(0),
+		func(variable *uint64, envVar string, value uint64) snek.FlagInitializer {
+			return snek.WithUint64VarPE(variable, "test", "t", envVar, value, "test uint64")
+		},
+		map[string]flagEnvTest[uint64]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: 0,
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "42",
+				setEnv:   true,
+				expected: 42,
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=99"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 99,
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "7"},
+				envValue: "42",
+				setEnv:   true,
+				expected: 7,
+			},
+			"invalid env var": {
+				envValue:    "notauint",
+				setEnv:      true,
+				wantInitErr: true,
+			},
+		})
+}
+
+// ---- string ----
+
+func TestWithStringVarE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_STRING",
+		"default",
+		func(variable *string, envVar string, value string) snek.FlagInitializer {
+			return snek.WithStringVarE(variable, "test", envVar, value, "test string")
+		},
+		map[string]flagEnvTest[string]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: "default",
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "from-env",
+				setEnv:   true,
+				expected: "from-env",
+			},
+			"cli flag overrides env var": {
+				args:     []string{"--test=from-flag"},
+				envValue: "from-env",
+				setEnv:   true,
+				expected: "from-flag",
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "from-flag"},
+				expected: "from-flag",
+			},
+		})
+}
+
+func TestWithStringVarPE(t *testing.T) {
+	runFlagEnvTest(t,
+		"TEST_STRING",
+		"default",
+		func(variable *string, envVar string, value string) snek.FlagInitializer {
+			return snek.WithStringVarPE(variable, "test", "t", envVar, value, "test string")
+		},
+		map[string]flagEnvTest[string]{
+			"no env var, no flag": {
+				args:     []string{},
+				expected: "default",
+			},
+			"env var set, no flag": {
+				args:     []string{},
+				envValue: "from-env",
+				setEnv:   true,
+				expected: "from-env",
+			},
+			"long flag overrides env var": {
+				args:     []string{"--test=from-flag"},
+				envValue: "from-env",
+				setEnv:   true,
+				expected: "from-flag",
+			},
+			"short flag overrides env var": {
+				args:     []string{"-t", "from-flag"},
+				envValue: "from-env",
+				setEnv:   true,
+				expected: "from-flag",
+			},
+			"cli flag set, no env var": {
+				args:     []string{"--test", "from-flag"},
+				expected: "from-flag",
+			},
+		})
+}


### PR DESCRIPTION
## Summary

- Adds `WithXxxVarE` and `WithXxxVarPE` `FlagInitializer` variants for all existing flag types (`bool`, `time.Duration`, `float32`, `float64`, `int`/`int8`/`int16`/`int32`/`int64`, `uint`/`uint8`/`uint16`/`uint32`/`uint64`, `string`)
- When the specified environment variable is set, its value is used as the flag default; explicit CLI flags always take priority
- Invalid env var values (unparseable for the flag's type) surface as `ErrFlagEnvVarInvalid` during `NewCommand`
- Fixes the GitHub Actions badge URL in the README (`master.yml` → `main.yml`)

## Test plan

- [ ] `go test ./...` passes
- [ ] Each new `WithXxxVarE`/`WithXxxVarPE` function has tests covering: no env/no flag (default wins), env set/no flag (env wins), CLI flag with env set (CLI wins), CLI flag without env (CLI wins), invalid env var (error wraps `ErrFlagEnvVarInvalid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)