### PR TITLE
Fix root command with subcommands rejecting positional args

### DIFF
--- a/run.go
+++ b/run.go
@@ -65,10 +65,8 @@ func RunExit(cfg *Config, initializers ...Initializer) {
 //	snek.WithDefaultLogLevel
 //	snek.WithLogOutput
 //
-// Logging is setup by using a cobra.OnInitialize function. This function will
-// setup logging using the configured log format and level. If an error occurs
-// while setting up logging, then the application will exit with a status code
-// of 1.
+// Logging is setup using a PersistentPreRunE hook on the root command. If an
+// error occurs while setting up logging, it is returned from Run.
 //
 // If the log level is set to `debug`, then a debug log line is written confirming
 // that debug logging is enabled.
@@ -96,6 +94,14 @@ func Run(args []string, cfg *Config, initializers ...Initializer) error {
 		return err
 	}
 
+	// When the root command is runnable (has Run/RunE) and also has subcommands,
+	// cobra's legacyArgs validation in Find() rejects any positional arguments
+	// with an "unknown command" error. Auto-apply ArbitraryArgs when no custom
+	// Args validator has been set so the root Run handler receives them normally.
+	if rootCmd.Args == nil && rootCmd.Runnable() && rootCmd.HasSubCommands() {
+		rootCmd.Args = cobra.ArbitraryArgs
+	}
+
 	// ---------------------------------------------------------------------------
 	// Logging
 	// ---------------------------------------------------------------------------
@@ -121,12 +127,24 @@ func Run(args []string, cfg *Config, initializers ...Initializer) error {
 		logLevel,
 		cfg.LogLevelCommandLineVariableHelp)
 
-	cobra.OnInitialize(func() {
+	// Use PersistentPreRunE instead of cobra.OnInitialize to scope logging setup
+	// to this command tree rather than the package-level global, which accumulates
+	// across multiple Run() calls (e.g. in tests). Chain any hooks the caller may
+	// have already set via initializers so neither is lost.
+	existingPreRunE := rootCmd.PersistentPreRunE
+	existingPreRun := rootCmd.PersistentPreRun
+	rootCmd.PersistentPreRunE = func(cmd *Command, args []string) error {
 		if err := setupLogging(logLevel, logFormat, cfg.LogOutput); err != nil {
-			log.Error().Err(err).Msg("Error setting up logging")
-			os.Exit(1)
+			return err
 		}
-	})
+		if existingPreRunE != nil {
+			return existingPreRunE(cmd, args)
+		}
+		if existingPreRun != nil {
+			existingPreRun(cmd, args)
+		}
+		return nil
+	}
 
 	// ---------------------------------------------------------------------------
 	// Execute

--- a/run.go
+++ b/run.go
@@ -138,7 +138,9 @@ func Run(args []string, cfg *Config, initializers ...Initializer) error {
 			return err
 		}
 		if existingPreRunE != nil {
-			return existingPreRunE(cmd, args)
+			if err := existingPreRunE(cmd, args); err != nil {
+				return err
+			}
 		}
 		if existingPreRun != nil {
 			existingPreRun(cmd, args)

--- a/run_test.go
+++ b/run_test.go
@@ -3,6 +3,7 @@ package snek_test
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -402,7 +403,7 @@ func TestRun_Execute_RootWithSubCommands_NoArgs(t *testing.T) {
 	require.NoError(t, err)
 
 	rootCalled := false
-	err = snek.Run([]string{}, snek.NewConfig(),
+	err = snek.Run([]string{}, snek.NewConfig(snek.WithLogOutput(io.Discard)),
 		snek.WithUse("root"),
 		snek.WithRun(func(cmd *cobra.Command, args []string) {
 			rootCalled = true
@@ -424,7 +425,7 @@ func TestRun_Execute_RootWithSubCommands_SubCommand(t *testing.T) {
 	require.NoError(t, err)
 
 	rootCalled := false
-	err = snek.Run([]string{"sub"}, snek.NewConfig(),
+	err = snek.Run([]string{"sub"}, snek.NewConfig(snek.WithLogOutput(io.Discard)),
 		snek.WithUse("root"),
 		snek.WithRun(func(cmd *cobra.Command, args []string) {
 			rootCalled = true
@@ -444,7 +445,7 @@ func TestRun_Execute_RootWithSubCommands_PositionalArgs(t *testing.T) {
 	require.NoError(t, err)
 
 	var gotArgs []string
-	err = snek.Run([]string{"foo", "bar"}, snek.NewConfig(),
+	err = snek.Run([]string{"foo", "bar"}, snek.NewConfig(snek.WithLogOutput(io.Discard)),
 		snek.WithUse("root"),
 		snek.WithRun(func(cmd *cobra.Command, args []string) {
 			gotArgs = args

--- a/run_test.go
+++ b/run_test.go
@@ -394,6 +394,68 @@ func runLogLinesJsonTest(t *testing.T, level string, expectedLines int, args []s
 	), expectedLines, args)
 }
 
+func TestRun_Execute_RootWithSubCommands_NoArgs(t *testing.T) {
+	subCmd, err := snek.NewCommand(
+		snek.WithUse("sub"),
+		snek.WithRun(func(cmd *cobra.Command, args []string) {}),
+	)
+	require.NoError(t, err)
+
+	rootCalled := false
+	err = snek.Run([]string{}, snek.NewConfig(),
+		snek.WithUse("root"),
+		snek.WithRun(func(cmd *cobra.Command, args []string) {
+			rootCalled = true
+		}),
+		snek.WithSubCommand(subCmd),
+	)
+	assert.NoError(t, err, "Run should not return an error when root has no args")
+	assert.True(t, rootCalled, "root Run should be called when no args are provided")
+}
+
+func TestRun_Execute_RootWithSubCommands_SubCommand(t *testing.T) {
+	subCalled := false
+	subCmd, err := snek.NewCommand(
+		snek.WithUse("sub"),
+		snek.WithRun(func(cmd *cobra.Command, args []string) {
+			subCalled = true
+		}),
+	)
+	require.NoError(t, err)
+
+	rootCalled := false
+	err = snek.Run([]string{"sub"}, snek.NewConfig(),
+		snek.WithUse("root"),
+		snek.WithRun(func(cmd *cobra.Command, args []string) {
+			rootCalled = true
+		}),
+		snek.WithSubCommand(subCmd),
+	)
+	assert.NoError(t, err, "Run should not return an error when a valid subcommand is provided")
+	assert.True(t, subCalled, "subcommand Run should be called when its name is provided")
+	assert.False(t, rootCalled, "root Run should not be called when a subcommand is provided")
+}
+
+func TestRun_Execute_RootWithSubCommands_PositionalArgs(t *testing.T) {
+	subCmd, err := snek.NewCommand(
+		snek.WithUse("sub"),
+		snek.WithRun(func(cmd *cobra.Command, args []string) {}),
+	)
+	require.NoError(t, err)
+
+	var gotArgs []string
+	err = snek.Run([]string{"foo", "bar"}, snek.NewConfig(),
+		snek.WithUse("root"),
+		snek.WithRun(func(cmd *cobra.Command, args []string) {
+			gotArgs = args
+		}),
+		snek.WithSubCommand(subCmd),
+	)
+	assert.NoError(t, err, "Run should not return an error when positional args are passed to root")
+	assert.Equal(t, []string{"foo", "bar"}, gotArgs,
+		"root Run should receive the positional args")
+}
+
 func testEnvironmentVariable(t *testing.T, name, value string) func() {
 	t.Helper()
 	oldValue, existed := os.LookupEnv(name)


### PR DESCRIPTION
## Summary

- **Bug fix**: When a root command had both a `Run`/`RunE` handler and subcommands, cobra's `legacyArgs` validation in `Find()` rejected any positional arguments with an `unknown command` error. `Run()` now auto-applies `cobra.ArbitraryArgs` on the root command when no custom `Args` validator has been set, so the root handler receives positional args as expected.
- **Secondary fix**: Replace `cobra.OnInitialize` with `PersistentPreRunE` for logging setup. `cobra.OnInitialize` appends to a package-level global, causing initializers to accumulate across multiple `Run()` calls (e.g. across test cases). The new approach scopes the hook to the command tree and propagates errors through `Execute()` instead of calling `os.Exit(1)` directly. Any `PersistentPreRunE` or `PersistentPreRun` the caller set via initializers is chained so neither is lost.

## Test plan

- [ ] `TestRun_Execute_RootWithSubCommands_NoArgs` — root `Run` fires when no args are passed
- [ ] `TestRun_Execute_RootWithSubCommands_SubCommand` — subcommand `Run` fires (not root) when subcommand name is passed
- [ ] `TestRun_Execute_RootWithSubCommands_PositionalArgs` — root `Run` receives positional args instead of returning `unknown command` error
- [ ] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)